### PR TITLE
Process: use waittid() to fix unreasonable bug.

### DIFF
--- a/mozart++/mpp_system/process.hpp
+++ b/mozart++/mpp_system/process.hpp
@@ -130,14 +130,14 @@ namespace mpp {
         }
 
         int wait_for() {
-            if (is_exited() && _this->_exit_code >= 0) {
+            if (has_exited() && _this->_exit_code >= 0) {
                 return _this->_exit_code;
             }
             _this->_exit_code = mpp_impl::wait_for(_this->_info);
             return _this->_exit_code;
         }
 
-        bool is_exited() const {
+        bool has_exited() const {
             return mpp_impl::process_exited(_this->_info);
         }
 


### PR DESCRIPTION
:)

Before:
![{6EB3FB8F-04B6-0C63-D0EF-3025893CEA76}](https://user-images.githubusercontent.com/9902643/75010952-6053a980-54b9-11ea-98b5-39c9327b202e.jpg)

After:
![_9W8T$LNCX_(~Y1A)~P} FC](https://user-images.githubusercontent.com/9902643/75010964-677ab780-54b9-11ea-87aa-8c9d53a3668a.jpg)
